### PR TITLE
Update GSoC script to use the new plugin update site for wikipedia and pt_assistant snapshots

### DIFF
--- a/josm_GSoC.sh
+++ b/josm_GSoC.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 
 configfolder="$HOME/.config/JOSM"
-localsharefolder="$HOME/.local/share/JOSM"
-
-mkdir -p $localsharefolder/plugins
+josmjarfolder="$HOME/Desktop"
 
 preferences=$configfolder/preferences.xml
 if [ ! -f $preferences ]; then
@@ -19,16 +17,10 @@ echo $josmjar
 
 url="https://josm.openstreetmap.de/download/$josmjar"
 echo $url
-output=~"/Desktop/$josmjar"
+output="$josmjarfolder/$josmjar"
 echo $output
-wget -N $url -P ~/Desktop/
+wget -N $url -P "$josmjarfolder/"
 #chmod +x $output
 
-pluginfolder=$localsharefolder/plugins
-
-echo $pluginfolder
-wget -nd "https://drive.google.com/uc?export=download&id=1JgBV-_6R79gxTqcraHia_nW5WwrEJcrF" -O "pt_assistant.jar"
-mv pt_assistant.jar "$pluginfolder"
-
-java -Xmx1950M -classpath "/home/jo/Desktop/josm-latest.jar" org.openstreetmap.josm.gui.MainApplication
+java -Xmx1950M -classpath "$josmjarfolder/$josmjar" org.openstreetmap.josm.gui.MainApplication --load-preferences="./josm_GSoC_preferences_mod.xml"
 sleep 1h

--- a/josm_GSoC_preferences_mod.xml
+++ b/josm_GSoC_preferences_mod.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- See https://josm.openstreetmap.de/wiki/Help/Preferences/ImportExport for documentation on this format -->
+<config>
+  <preferences operation="append">
+    <list key='pluginmanager.sites'>
+      <entry value='https://josm.github.io/wikipedia/pluginMasterSnapshots'/>
+    </list>
+  </preferences>
+  <plugin install="wikipedia-dev;pt_assistant-dev" remove="wikipedia;pt_assistant"/>
+</config>


### PR DESCRIPTION
It now automatically installs the JOSM plugin update site https://josm.github.io/wikipedia/pluginMasterSnapshots and downloads and installs both the `wikipedia-dev` and `pt_assistant-dev` plugin.
See https://josm.github.io/wikipedia/ for how to install the plugin site manually.